### PR TITLE
Update librsvg to 2.58.0 and gdk-pixbuf to 2.42.9

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 **
+!fix_gdk-pixbuf_static_dependencies.patch
 !cloud.svg

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,9 @@ ENV CMAKE_VERSION=3.18.2 \
     HARFBUZZ_VERSION=5.0.1 \
     PIXMAN_VERSION=0.40.0 \
     CAIRO_VERSION=1.17.4 \
-    LIBRSVG_VERSION=2.54.4 \
-    LIBRSVG_MINOR_VERSION=2.54 \
-    GDK_PIXBUF_VERSION=2.42.8 \
+    LIBRSVG_VERSION=2.58.0 \
+    LIBRSVG_MINOR_VERSION=2.58 \
+    GDK_PIXBUF_VERSION=2.42.9 \
     GDK_PIXBUF_MINOR_VERSION=2.42 \
     LIBFFI_VERSION=3.3 \
     BZIP2_VERSION=1.0.6 \
@@ -163,10 +163,14 @@ RUN cd glib-* && \
 ENV GDK_PIXBUF_MODULEDIR=${TARGET_DIR}/lib/gdk-pixbuf-loaders \
     GDK_PIXBUF_MODULE_FILE=${TARGET_DIR}/lib/gdk-pixbuf-loaders.cache
 
+# apply patch to fix static builds - from https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/161
+COPY fix_gdk-pixbuf_static_dependencies.patch /tmp/
+
 # builtin_loaders: eh
 RUN cd gdk-pixbuf-* && \
+    patch -p1 -i /tmp/fix_gdk-pixbuf_static_dependencies.patch && \
     meson --prefix ${CACHE_DIR} _build -Dintrospection=disabled -Ddefault_library=static \
-        -Drelocatable=true -Dgio_sniffing=false -Dbuiltin_loaders=jpeg,png -Dinstalled_tests=false && \
+        -Drelocatable=true -Dgio_sniffing=false -Dbuiltin_loaders=jpeg,png -Dinstalled_tests=false -Dman=false && \
     ninja -C _build && \
     ninja -C _build install
 

--- a/fix_gdk-pixbuf_static_dependencies.patch
+++ b/fix_gdk-pixbuf_static_dependencies.patch
@@ -1,0 +1,29 @@
+From 1b7cac1cbdb7078f575a3222be451a9bf1ac35ec Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Wed, 31 Jan 2024 15:33:02 +0100
+Subject: [PATCH] build: add missing dependency to gdkpixbuf_dep
+
+This should match the dependencies passed to the library() call that
+creates gdkpixbuf.  Otherwise, linking the gdkpixbuf_bin executables
+will fail if -Ddefault_library=static, because static libraries don't
+carry dependency information themselves.
+---
+ gdk-pixbuf/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdk-pixbuf/meson.build b/gdk-pixbuf/meson.build
+index a11926eee..450484d68 100644
+--- a/gdk-pixbuf/meson.build
++++ b/gdk-pixbuf/meson.build
+@@ -269,7 +269,7 @@ endif
+ gdkpixbuf_dep = declare_dependency(
+   link_with: gdkpixbuf,
+   include_directories: root_inc,
+-  dependencies: gdk_pixbuf_deps,
++  dependencies: [ gdk_pixbuf_deps, included_loaders_deps ],
+   sources: [ gdkpixbuf_enum_h, built_girs ],
+ )
+ meson.override_dependency('gdk-pixbuf-2.0', gdkpixbuf_dep)
+-- 
+GitLab
+


### PR DESCRIPTION
This commit updates librsvg to version 2.58.0 and gdk-pixbuf to version 2.42.9. It contains a patch to fix static gdx-pixbuf builds that is not merged into upstream yet.

Source for the patch: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/161